### PR TITLE
TextEncoder doesn't take an argument

### DIFF
--- a/tokenizer.js
+++ b/tokenizer.js
@@ -20,7 +20,7 @@ async function loadSimpleTokenizer() {
 // Credit to https://github.com/latitudegames/GPT-3-Encoder
 
 const pat = /'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+/gu;
-const textEncoder = new TextEncoder("utf-8");
+const textEncoder = new TextEncoder(); // always utf-8 by spec
 const textDecoder = new TextDecoder("utf-8");
 
 async function loadGPT2Tokenizer() {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/TextEncoder
It's fixed to utf-8 by spec and won't change. Removed the slightly confusing argument
