### PR TITLE
De-embeddings on GPU + major temperature/top_k bug fix!

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -166,12 +166,6 @@ function flattenEmbeddings(embeddings, n_embd, seq_length) {
   return flattened;
 }
 
-function wasted_memory(vocab_size, n_embd, columns) {
-  const subMatrixCount = math.ceil(vocab_size / columns);
-  const totalElementsInSubMatrices = subMatrixCount * columns * n_embd;
-  return totalElementsInSubMatrices - vocab_size * n_embd;
-}
-
 function leastPrimeFactor(n, start = 2) {
   for (let i = start; i <= Math.sqrt(n); i++) {
     if (n % i === 0) return i;

--- a/helpers.js
+++ b/helpers.js
@@ -166,3 +166,16 @@ function flattenEmbeddings(embeddings, n_embd, seq_length) {
   for (const [i, v] of embeddings.entries()) flattened.set(v, n_embd * i);
   return flattened;
 }
+
+function wasted_memory(vocab_size, n_embd, columns) {
+  const subMatrixCount = math.ceil(vocab_size / columns);
+  const totalElementsInSubMatrices = subMatrixCount * columns * n_embd;
+  return totalElementsInSubMatrices - vocab_size * n_embd;
+}
+
+function leastPrimeFactor(n, start = 2) {
+  for (let i = start; i <= Math.sqrt(n); i++) {
+    if (n % i === 0) return i;
+  }
+  return n;
+}

--- a/helpers.js
+++ b/helpers.js
@@ -96,27 +96,16 @@ let bufferSizeCalc = (dimA, dimB = 1) => {
   throw new Error("BufferSizeCalc not initialized.");
 };
 
-function sampleFromDistribution(probs, top_k) {
-  const sortedIndices = Array.from(probs)
-    .map((value, index) => ({ value, index }))
-    .sort((a, b) => b.value - a.value)
-    .map(({ index }) => index);
-
-  const topKIndices = sortedIndices.slice(0, top_k);
-  const topKProbs = topKIndices.map((index) => probs[index]);
-
-  const sumTopKProbs = topKProbs.reduce((a, b) => a + b, 0);
-  const normalizedTopKProbs = topKProbs.map((prob) => prob / sumTopKProbs);
-
+function sampleFromDistribution(probs) {
   const rand = Math.random();
   let cumulativeProb = 0;
-  for (let i = 0; i < top_k; i++) {
-    cumulativeProb += normalizedTopKProbs[i];
+  for (let i = 0; i < probs.length; i++) {
+    cumulativeProb += probs[i];
     if (rand < cumulativeProb) {
-      return topKIndices[i];
+      return i;
     }
   }
-  return topKIndices[top_k - 1];
+  return probs.length - 1;
 }
 
 function cpuSoftmax(logits, temperature = 1.0) {
@@ -124,6 +113,16 @@ function cpuSoftmax(logits, temperature = 1.0) {
   const expLogits = logits.map((logit) => Math.exp((logit - maxLogit) / temperature));
   const sumExpLogits = expLogits.reduce((a, b) => a + b, 0);
   return expLogits.map((expLogit) => expLogit / sumExpLogits);
+}
+
+function selectTopK(probs, top_k) {
+  const sortedIndices = Array.from(probs)
+    .map((value, index) => ({ value, index }))
+    .sort((a, b) => b.value - a.value)
+    .map(({ index }) => index);
+  const topKIndices = sortedIndices.slice(0, top_k);
+  const topKProbs = topKIndices.map((index) => probs[index]);
+  return { topKIndices, topKProbs };
 }
 
 // ----------------------- Matrix Operations -----------------------

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <input type="number" min="1" max="300" value="100" id="tokensInput" disabled />
     <br /><br />
     <label for="topK">Top K:</label>
-    <input type="number" min="1" max="100" value="1" id="topKInput" disabled />
+    <input type="number" min="1" max="100" value="5" id="topKInput" disabled />
     <br /><br />
     <label for="temperature">Temperature:</label>
     <input type="number" step="0.01" min="0.1" max="2" value="1" id="temperatureInput" disabled />
@@ -31,7 +31,7 @@
     <textarea id="prompt" rows="15" cols="50" disabled>
 WILL:
 Ah, how dare you challenge me?
-Have you forgotten I built WebGPT? </textarea
+Have you forgotten I built WebGPT?&#13;&#10;</textarea
     >
     <br /><br />
     <script>
@@ -64,7 +64,7 @@ Have you forgotten I built WebGPT? </textarea
 
         const topK = topKInput.value;
         const temperature = temperatureInput.value;
-        const textStream = generate(prompt, numTokens, 10, topK, temperature);
+        const textStream = generate(prompt, numTokens, topK, temperature);
 
         for await (const text of textStream) {
           promptTextarea.value += text;
@@ -83,7 +83,7 @@ Have you forgotten I built WebGPT? </textarea
         topKInput.disabled = false;
         temperatureInput.disabled = false;
 
-        startGeneration();
+        // startGeneration();
       }
 
       async function loadGPT2ModelHandler() {

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <input type="number" min="1" max="300" value="100" id="tokensInput" disabled />
     <br /><br />
     <label for="topK">Top K:</label>
-    <input type="number" min="1" max="100" value="5" id="topKInput" disabled />
+    <input type="number" min="1" max="100" value="2" id="topKInput" disabled />
     <br /><br />
     <label for="temperature">Temperature:</label>
     <input type="number" step="0.01" min="0.1" max="2" value="1" id="temperatureInput" disabled />

--- a/index.html
+++ b/index.html
@@ -28,10 +28,11 @@
     <br /><br />
     <button id="generateButton" onclick="startGeneration()" disabled>Generate Text</button>
     <br /><br />
-    <textarea id="prompt" rows="5" cols="50" disabled>
+    <textarea id="prompt" rows="15" cols="50" disabled>
 WILL:
 Ah, how dare you challenge me?
-Have you forgotten I built WebGPT? </textarea>
+Have you forgotten I built WebGPT? </textarea
+    >
     <br /><br />
     <script>
       const webgpuSupportMessage = document.getElementById("webgpuSupportMessage");
@@ -39,8 +40,8 @@ Have you forgotten I built WebGPT? </textarea>
       const loadGPT2ModelButton = document.getElementById("loadGPT2ModelButton");
 
       const tokensInput = document.getElementById("tokensInput");
-      const topKInput = document.getElementById("topKInput")
-      const temperatureInput = document.getElementById("temperatureInput")
+      const topKInput = document.getElementById("topKInput");
+      const temperatureInput = document.getElementById("temperatureInput");
       const generateButton = document.getElementById("generateButton");
       const promptTextarea = document.getElementById("prompt");
 
@@ -81,6 +82,8 @@ Have you forgotten I built WebGPT? </textarea>
         tokensInput.disabled = false;
         topKInput.disabled = false;
         temperatureInput.disabled = false;
+
+        startGeneration();
       }
 
       async function loadGPT2ModelHandler() {
@@ -124,6 +127,8 @@ Have you forgotten I built WebGPT? </textarea>
 
         setTextareaDisabled(false);
       }
+
+      // loadModelHandler();
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -82,8 +82,6 @@ Have you forgotten I built WebGPT?&#13;&#10;</textarea
         tokensInput.disabled = false;
         topKInput.disabled = false;
         temperatureInput.disabled = false;
-
-        // startGeneration();
       }
 
       async function loadGPT2ModelHandler() {
@@ -127,8 +125,6 @@ Have you forgotten I built WebGPT?&#13;&#10;</textarea
 
         setTextareaDisabled(false);
       }
-
-      // loadModelHandler();
     </script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -141,114 +141,6 @@ async function runGPT(idx) {
 
   const layerNormOutputBuffer = inlineLayerNorm(device, queue, commandEncoder, seq_length, n_embd, layerOutputBuffer, normGammaBuffer, normBetaBuffer);
 
-  const outputBuffer = createOutputBuffer(device, commandEncoder, layerNormOutputBuffer, seq_length, n_embd);
-
-  queue.submit([commandEncoder.finish()]);
-
-  await outputBuffer.mapAsync(GPUMapMode.READ);
-  const output = outputBuffer.getMappedRange();
-  const deEmbed = deEmbedCPU(output, embeddingWeights, seq_length, n_embd, vocab_size);
-
-  return new Float32Array(deEmbed);
-}
-
-async function runGPTNew(idx) {
-  if (!modelParams) {
-    console.log("Model not loaded yet");
-    return;
-  }
-
-  const { device, queue, params, posEmbdBuffer, layer_buffers, normGammaBuffer, normBetaBuffer, embeddingWeights } = modelParams;
-  const { attentionDotProductScale, n_embd, n_head, n_layer, vocab_size, hidden_size } = params;
-  const seq_length = idx.length;
-
-  const embeddings = idx.map((token) => embeddingWeights.slice(token * n_embd, (token + 1) * n_embd));
-  const flattened = flattenEmbeddings(embeddings, n_embd, seq_length);
-  const embdOutputBuffer = createBuffer(device, bufferSizeCalc(seq_length, n_embd), GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST);
-  queue.writeBuffer(embdOutputBuffer, 0, flattened);
-
-  const commandEncoder = device.createCommandEncoder();
-
-  // Crop the position embeddings to the correct size.
-  const posEmbdOutputBuffer = createBuffer(
-    device,
-    bufferSizeCalc(seq_length, n_embd),
-    GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
-  );
-  commandEncoder.copyBufferToBuffer(
-    posEmbdBuffer, // Source buffer (original position embeddings)
-    0, // Source offset (starting from the beginning of the buffer)
-    posEmbdOutputBuffer, // Destination buffer (cropped buffer)
-    0, // Destination offset (starting from the beginning of the cropped buffer)
-    bufferSizeCalc(seq_length, n_embd) // Number of bytes to copy
-  );
-  // Residual connection is just elementwise addition, can be used for combining embedding and position embedding.
-  const embeddedInputBuffer = inlineResidual(device, queue, commandEncoder, seq_length, n_embd, embdOutputBuffer, posEmbdOutputBuffer);
-  let layerOutputBuffer = embeddedInputBuffer;
-
-  for (let i = 0; i < n_layer; i++) {
-    const buffers = layer_buffers[i];
-
-    const layerNormAttentionOutputBuffer = inlineLayerNorm(
-      device,
-      queue,
-      commandEncoder,
-      seq_length,
-      n_embd,
-      layerOutputBuffer,
-      buffers.normAttentionGammaBuffer,
-      buffers.normAttentionBetaBuffer
-    );
-
-    const attentionOutputBuffer = inlineAttention(
-      device,
-      queue,
-      commandEncoder,
-      seq_length,
-      n_embd,
-      attentionDotProductScale,
-      layerNormAttentionOutputBuffer,
-      n_head,
-      buffers.qkvWeightsBuffer,
-      buffers.qkvBiasBuffer,
-      buffers.linearWeightsBuffer,
-      buffers.linearBiasBuffer
-    );
-
-    const residualAttentionOutputBuffer = inlineResidual(device, queue, commandEncoder, seq_length, n_embd, attentionOutputBuffer, layerOutputBuffer);
-
-    const layerNormLinearOutputBuffer = inlineLayerNorm(
-      device,
-      queue,
-      commandEncoder,
-      seq_length,
-      n_embd,
-      residualAttentionOutputBuffer,
-      buffers.normLinearGammaBuffer,
-      buffers.normLinearBetaBuffer
-    );
-
-    const linearOutputBuffer = inlineFFN(
-      device,
-      queue,
-      commandEncoder,
-      seq_length,
-      n_embd,
-      hidden_size,
-      layerNormLinearOutputBuffer,
-      buffers.firstLayerWeightsBuffer,
-      buffers.firstLayerBiasBuffer,
-      buffers.secondLayerWeightsBuffer,
-      buffers.secondLayerBiasBuffer
-    );
-
-    const residualLinearOutputBuffer = inlineResidual(device, queue, commandEncoder, seq_length, n_embd, linearOutputBuffer, residualAttentionOutputBuffer);
-
-    layerOutputBuffer = residualLinearOutputBuffer;
-  }
-
-  const layerNormOutputBuffer = inlineLayerNorm(device, queue, commandEncoder, seq_length, n_embd, layerOutputBuffer, normGammaBuffer, normBetaBuffer);
-
   /* 
     Compute Pass Splitting: Possible Approaches.
 
@@ -288,10 +180,15 @@ async function runGPTNew(idx) {
 
   // Assumes that vocab_size has a decent least prime factor.
   const maxStorageBufferSize = device.limits.maxStorageBufferBindingSize;
-  const totalElements = n_embd * vocab_size;
+  const totalElements = bufferSizeCalc(vocab_size, n_embd);
   var numInstances = Math.ceil(totalElements / maxStorageBufferSize);
   if (numInstances > 1) numInstances = leastPrimeFactor(vocab_size, numInstances);
   var vocabChunkSize = vocab_size / numInstances;
+
+  console.log("maxStorageBufferSize: " + maxStorageBufferSize);
+  console.log("totalElements: " + totalElements);
+  console.log("numInstances: " + numInstances);
+  console.log("vocabChunkSize: " + vocabChunkSize);
 
   for (let i = 0; i < numInstances; i++) {
     const deEmbedChunkInputBuffer = createBuffer(

--- a/main.js
+++ b/main.js
@@ -185,11 +185,6 @@ async function runGPT(idx) {
   if (numInstances > 1) numInstances = leastPrimeFactor(vocab_size, numInstances);
   var vocabChunkSize = vocab_size / numInstances;
 
-  console.log("maxStorageBufferSize: " + maxStorageBufferSize);
-  console.log("totalElements: " + totalElements);
-  console.log("numInstances: " + numInstances);
-  console.log("vocabChunkSize: " + vocabChunkSize);
-
   for (let i = 0; i < numInstances; i++) {
     const deEmbedChunkInputBuffer = createBuffer(
       device,

--- a/main.js
+++ b/main.js
@@ -141,15 +141,84 @@ async function runGPT(idx) {
 
   const layerNormOutputBuffer = inlineLayerNorm(device, queue, commandEncoder, seq_length, n_embd, layerOutputBuffer, normGammaBuffer, normBetaBuffer);
 
-  const outputBuffer = createOutputBuffer(device, commandEncoder, layerNormOutputBuffer, seq_length, n_embd);
+  /* 
+    Compute Pass Splitting: Possible Approaches.
+
+    The limiting factor running larger models is often the maxStorageBufferBindingSize, which prevents you from doing giant matrix multiplications. As far as I know, the best way to solve this is to generate multiple compute passes and split the calculation into smaller sub-matrices. You can simply write back to the buffer with the proper offset and byte size and nothing changes. As long as these operations don't have inter-dependencies, WebGPU should recognize that they can be run in parallel and you shouldn't experience significant performance losses. This needs to be verified!
+
+    The question then is to how to divide the operation properly for efficiency. I'm still figuring out how everything works, so I'm unsure what the most efficient way to do this is.
+
+    The first thought is that if you have a matrix of elements maxStorageBufferBindingSize * 2, it's straightforward to chop it down the middle. However for non-evenly divisible matrix sizes, you might run into serious memory inefficiencies if you divide by the minimum number of sub-matrices. 
+
+    I've implemented/planned a couple different solutions.
+
+    (1) Start with the minimum number of groups and calculate wasted memory, then increase # of groups and record the most efficient sizing up to some maximum group number. This calculation can be done when the model is loaded.
+
+    (2) Divide by some standard matrix size (maybe a square matrix of rows * rows) and then add one final "overflow matrix" of some irregular size. I really don't know if this is more efficient, still learning, but my gut tells me this might be result in too many groups when fewer could do better.
+    
+    (3) Assume that the matrix has some decently small factor that fits perfectly and use that. This is the simplest solution, and given that I have 0 clue which option is best until I test, I'm going with this for now.
+
+  */
+
+  const slicedEmbedOutputBuffer = createBuffer(device, bufferSizeCalc(1, n_embd), GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC);
+  commandEncoder.copyBufferToBuffer(
+    layerNormOutputBuffer, // Source buffer (original position embeddings)
+    bufferSizeCalc(seq_length - 1, n_embd), // Source offset (starting from the beginning of the buffer)
+    slicedEmbedOutputBuffer, // Destination buffer (cropped buffer)
+    0, // Destination offset (starting from the beginning of the cropped buffer)
+    bufferSizeCalc(1, n_embd) // Number of bytes to copy
+  );
+
+  const embeddingWeightsBuffer = createBuffer(
+    device,
+    bufferSizeCalc(vocab_size, n_embd),
+    GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
+  );
+  queue.writeBuffer(embeddingWeightsBuffer, 0, transposeArray(embeddingWeights, vocab_size, n_embd));
+
+  const deEmbedOutputBuffer = createBuffer(device, bufferSizeCalc(1, vocab_size), GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ);
+
+  // Assumes that vocab_size has a decent least prime factor.
+  const maxStorageBufferSize = device.limits.maxStorageBufferBindingSize;
+  const totalElements = n_embd * vocab_size;
+  var numInstances = Math.ceil(totalElements / maxStorageBufferSize);
+  if (numInstances > 1) numInstances = leastPrimeFactor(vocab_size, numInstances);
+  var vocabChunkSize = vocab_size / numInstances;
+
+  for (let i = 0; i < numInstances; i++) {
+    const deEmbedChunkInputBuffer = createBuffer(
+      device,
+      bufferSizeCalc(n_embd, vocabChunkSize),
+      GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
+    );
+    // Remember that embeddingWeightsBuffer is transposed.
+    commandEncoder.copyBufferToBuffer(
+      embeddingWeightsBuffer,
+      i * bufferSizeCalc(n_embd * vocabChunkSize),
+      deEmbedChunkInputBuffer,
+      0,
+      bufferSizeCalc(n_embd, vocabChunkSize)
+    );
+    // We're doing some buffer tricks here. Since slicedlayerNormOutputBuffer is a row matrix, we can just pretend it's a column matrix without any changes to the way it's stored. We then multiply it by the transposed embeddingWeights chunk, resulting in a column vector which, once again, we can pretend is a row vector.
+    const deEmbedChunkResultBuffer = inlineMatMul(
+      device,
+      queue,
+      commandEncoder,
+      deEmbedChunkInputBuffer,
+      slicedlayerNormOutputBuffer,
+      vocabChunkSize,
+      1,
+      n_embd
+    );
+    commandEncoder.copyBufferToBuffer(deEmbedChunkResultBuffer, 0, deEmbedOutputBuffer, i * bufferSizeCalc(vocabChunkSize), bufferSizeCalc(vocabChunkSize));
+  }
 
   queue.submit([commandEncoder.finish()]);
 
-  await outputBuffer.mapAsync(GPUMapMode.READ);
-  const output = outputBuffer.getMappedRange();
-  const deEmbed = deEmbedCPU(output, embeddingWeights, seq_length, n_embd, vocab_size);
+  await deEmbedOutputBuffer.mapAsync(GPUMapMode.READ);
+  const output = deEmbedOutputBuffer.getMappedRange();
 
-  return new Float32Array(deEmbed);
+  return new Float32Array(output);
 }
 
 async function loadModel(folder) {

--- a/main.js
+++ b/main.js
@@ -32,8 +32,10 @@ async function* generate(prompt, max_new_tokens, top_k = 10, temperature = 1.0) 
     const idx_cond = history.slice(-block_size);
 
     const logits = await runGPT(idx_cond);
-    const probs = cpuSoftmax(logits, temperature);
-    const idx_next = sampleFromDistribution(probs, top_k);
+    const { topKIndices, topKProbs } = selectTopK(logits, top_k);
+    const probs = cpuSoftmax(topKProbs, temperature);
+    console.log(probs);
+    const idx_next = topKIndices[sampleFromDistribution(probs)];
 
     history = history.concat(idx_next);
 
@@ -44,6 +46,114 @@ async function* generate(prompt, max_new_tokens, top_k = 10, temperature = 1.0) 
 }
 
 async function runGPT(idx) {
+  if (!modelParams) {
+    console.log("Model not loaded yet");
+    return;
+  }
+
+  const { device, queue, params, posEmbdBuffer, layer_buffers, normGammaBuffer, normBetaBuffer, embeddingWeights } = modelParams;
+  const { attentionDotProductScale, n_embd, n_head, n_layer, vocab_size, hidden_size } = params;
+  const seq_length = idx.length;
+
+  const embeddings = idx.map((token) => embeddingWeights.slice(token * n_embd, (token + 1) * n_embd));
+  const flattened = flattenEmbeddings(embeddings, n_embd, seq_length);
+  const embdOutputBuffer = createBuffer(device, bufferSizeCalc(seq_length, n_embd), GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST);
+  queue.writeBuffer(embdOutputBuffer, 0, flattened);
+
+  const commandEncoder = device.createCommandEncoder();
+
+  // Crop the position embeddings to the correct size.
+  const posEmbdOutputBuffer = createBuffer(
+    device,
+    bufferSizeCalc(seq_length, n_embd),
+    GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
+  );
+  commandEncoder.copyBufferToBuffer(
+    posEmbdBuffer, // Source buffer (original position embeddings)
+    0, // Source offset (starting from the beginning of the buffer)
+    posEmbdOutputBuffer, // Destination buffer (cropped buffer)
+    0, // Destination offset (starting from the beginning of the cropped buffer)
+    bufferSizeCalc(seq_length, n_embd) // Number of bytes to copy
+  );
+  // Residual connection is just elementwise addition, can be used for combining embedding and position embedding.
+  const embeddedInputBuffer = inlineResidual(device, queue, commandEncoder, seq_length, n_embd, embdOutputBuffer, posEmbdOutputBuffer);
+  let layerOutputBuffer = embeddedInputBuffer;
+
+  for (let i = 0; i < n_layer; i++) {
+    const buffers = layer_buffers[i];
+
+    const layerNormAttentionOutputBuffer = inlineLayerNorm(
+      device,
+      queue,
+      commandEncoder,
+      seq_length,
+      n_embd,
+      layerOutputBuffer,
+      buffers.normAttentionGammaBuffer,
+      buffers.normAttentionBetaBuffer
+    );
+
+    const attentionOutputBuffer = inlineAttention(
+      device,
+      queue,
+      commandEncoder,
+      seq_length,
+      n_embd,
+      attentionDotProductScale,
+      layerNormAttentionOutputBuffer,
+      n_head,
+      buffers.qkvWeightsBuffer,
+      buffers.qkvBiasBuffer,
+      buffers.linearWeightsBuffer,
+      buffers.linearBiasBuffer
+    );
+
+    const residualAttentionOutputBuffer = inlineResidual(device, queue, commandEncoder, seq_length, n_embd, attentionOutputBuffer, layerOutputBuffer);
+
+    const layerNormLinearOutputBuffer = inlineLayerNorm(
+      device,
+      queue,
+      commandEncoder,
+      seq_length,
+      n_embd,
+      residualAttentionOutputBuffer,
+      buffers.normLinearGammaBuffer,
+      buffers.normLinearBetaBuffer
+    );
+
+    const linearOutputBuffer = inlineFFN(
+      device,
+      queue,
+      commandEncoder,
+      seq_length,
+      n_embd,
+      hidden_size,
+      layerNormLinearOutputBuffer,
+      buffers.firstLayerWeightsBuffer,
+      buffers.firstLayerBiasBuffer,
+      buffers.secondLayerWeightsBuffer,
+      buffers.secondLayerBiasBuffer
+    );
+
+    const residualLinearOutputBuffer = inlineResidual(device, queue, commandEncoder, seq_length, n_embd, linearOutputBuffer, residualAttentionOutputBuffer);
+
+    layerOutputBuffer = residualLinearOutputBuffer;
+  }
+
+  const layerNormOutputBuffer = inlineLayerNorm(device, queue, commandEncoder, seq_length, n_embd, layerOutputBuffer, normGammaBuffer, normBetaBuffer);
+
+  const outputBuffer = createOutputBuffer(device, commandEncoder, layerNormOutputBuffer, seq_length, n_embd);
+
+  queue.submit([commandEncoder.finish()]);
+
+  await outputBuffer.mapAsync(GPUMapMode.READ);
+  const output = outputBuffer.getMappedRange();
+  const deEmbed = deEmbedCPU(output, embeddingWeights, seq_length, n_embd, vocab_size);
+
+  return new Float32Array(deEmbed);
+}
+
+async function runGPTNew(idx) {
   if (!modelParams) {
     console.log("Model not loaded yet");
     return;

--- a/main.js
+++ b/main.js
@@ -34,7 +34,6 @@ async function* generate(prompt, max_new_tokens, top_k = 10, temperature = 1.0) 
     const logits = await runGPT(idx_cond);
     const { topKIndices, topKProbs } = selectTopK(logits, top_k);
     const probs = cpuSoftmax(topKProbs, temperature);
-    console.log(probs);
     const idx_next = topKIndices[sampleFromDistribution(probs)];
 
     history = history.concat(idx_next);

--- a/other/misc/in_prog.js
+++ b/other/misc/in_prog.js
@@ -95,15 +95,30 @@ async function runGPT(idx) {
 
   const layerNormOutputBuffer = inlineLayerNorm(device, queue, commandEncoder, seq_length, n_embd, layerOutputBuffer, normGammaBuffer, normBetaBuffer);
 
-  const slicedlayerNormOutputBuffer = createBuffer(
-    device,
-    bufferSizeCalc(1, n_embd),
-    GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
-  );
+  /* 
+    Compute Pass Splitting: Possible Approaches.
+
+    The limiting factor running larger models is often the maxStorageBufferBindingSize, which prevents you from doing giant matrix multiplications. As far as I know, the best way to solve this is to generate multiple compute passes and split the calculation into smaller sub-matrices. You can simply write back to the buffer with the proper offset and byte size and nothing changes. As long as these operations don't have inter-dependencies, WebGPU should recognize that they can be run in parallel and you shouldn't experience significant performance losses. This needs to be verified!
+
+    The question then is to how to divide the operation properly for efficiency. I'm still figuring out how everything works, so I'm unsure what the most efficient way to do this is.
+
+    The first thought is that if you have a matrix of elements maxStorageBufferBindingSize * 2, it's straightforward to chop it down the middle. However for non-evenly divisible matrix sizes, you might run into serious memory inefficiencies if you divide by the minimum number of sub-matrices. 
+
+    I've implemented/planned a couple different solutions.
+
+    (1) Start with the minimum number of groups and calculate wasted memory, then increase # of groups and record the most efficient sizing up to some maximum group number. This calculation can be done when the model is loaded.
+
+    (2) Divide by some standard matrix size (maybe a square matrix of rows * rows) and then add one final "overflow matrix" of some irregular size. I really don't know if this is more efficient, still learning, but my gut tells me this might be result in too many groups when fewer could do better.
+    
+    (3) Assume that the matrix has some decently small factor that fits perfectly and use that. This is the simplest solution, and given that I have 0 clue which option is best until I test, I'm going with this for now.
+
+  */
+
+  const slicedEmbedOutputBuffer = createBuffer(device, bufferSizeCalc(1, n_embd), GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC);
   commandEncoder.copyBufferToBuffer(
     layerNormOutputBuffer, // Source buffer (original position embeddings)
     bufferSizeCalc((seq_length - 1) * n_embd, n_embd), // Source offset (starting from the beginning of the buffer)
-    slicedlayerNormOutputBuffer, // Destination buffer (cropped buffer)
+    slicedEmbedOutputBuffer, // Destination buffer (cropped buffer)
     0, // Destination offset (starting from the beginning of the cropped buffer)
     bufferSizeCalc(1, n_embd) // Number of bytes to copy
   );
@@ -115,49 +130,47 @@ async function runGPT(idx) {
   );
   queue.writeBuffer(embeddingWeightsBuffer, 0, transposeArray(embeddingWeights, vocab_size, n_embd));
 
+  const deEmbedOutputBuffer = createBuffer(device, bufferSizeCalc(1, vocab_size), GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ);
+
+  // Assumes that vocab_size has a decent least prime factor.
   const maxStorageBufferSize = device.limits.maxStorageBufferBindingSize;
+  const totalElements = n_embd * vocab_size;
+  var numInstances = Math.ceil(totalElements / maxStorageBufferSize);
+  if (numInstances > 1) numInstances = leastPrimeFactor(vocab_size, numInstances);
+  var vocabChunkSize = vocab_size / numInstances;
 
-  // AFAIK, this should run in parallel because the encoder understands that they have no dependencies. Double check that deEmbed
-  const deEmbedOutputBuffer = createBuffer(device, bufferSizeCalc(seq_length, vocab_size), GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ);
-
-  const embedSize = vocab_size * n_embd;
-  const maxVocabChunkSize = Math.floor(maxStorageBufferSize / n_embd);
-  const numInstances = Math.ceil(vocab_size / maxVocabChunkSize);
-  const vocabChunkSize = maxStorageBufferSize;
-  console.log(embedSize, maxStorageBufferSize, numInstances, vocabChunkSize);
   for (let i = 0; i < numInstances; i++) {
-    const deEmbedInputBuffer = createBuffer(
+    const deEmbedChunkInputBuffer = createBuffer(
       device,
       bufferSizeCalc(n_embd, vocabChunkSize),
       GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
     );
+    // Remember that embeddingWeightsBuffer is transposed.
     commandEncoder.copyBufferToBuffer(
       embeddingWeightsBuffer,
-      i * bufferSizeCalc(seq_length, vocabChunkSize),
-      deEmbedInputBuffer,
+      i * bufferSizeCalc(n_embd * vocabChunkSize),
+      deEmbedChunkInputBuffer,
       0,
       bufferSizeCalc(n_embd, vocabChunkSize)
     );
-    const softMaxResultBuffer = inlineMatMul(
+    // We're doing some buffer tricks here. Since slicedlayerNormOutputBuffer is a row matrix, we can just pretend it's a column matrix without any changes to the way it's stored. We then multiply it by the transposed embeddingWeights chunk, resulting in a column vector which, once again, we can pretend is a row vector.
+    const deEmbedChunkResultBuffer = inlineMatMul(
       device,
       queue,
       commandEncoder,
+      deEmbedChunkInputBuffer,
       slicedlayerNormOutputBuffer,
-      deEmbedInputBuffer,
-      seq_length,
       vocabChunkSize,
+      1,
       n_embd
     );
-
-    const copySize = i === numInstances - 1 ? bufferSizeCalc(seq_length, vocab_size - vocabChunkSize * i) : bufferSizeCalc(seq_length, vocabChunkSize);
-    commandEncoder.copyBufferToBuffer(softMaxResultBuffer, 0, deEmbedOutputBuffer, i * bufferSizeCalc(seq_length, vocabChunkSize), copySize);
+    commandEncoder.copyBufferToBuffer(deEmbedChunkResultBuffer, 0, deEmbedOutputBuffer, i * bufferSizeCalc(vocabChunkSize), bufferSizeCalc(vocabChunkSize));
   }
 
   queue.submit([commandEncoder.finish()]);
 
   await deEmbedOutputBuffer.mapAsync(GPUMapMode.READ);
   const output = deEmbedOutputBuffer.getMappedRange();
-  const deEmbed = deEmbedCPU(output, embeddingWeights, seq_length, n_embd, vocab_size);
 
-  return new Float32Array(deEmbed);
+  return new Float32Array(output);
 }


### PR DESCRIPTION
I was previously running de-embeddings on the GPU because of the large size of multiplying by a matrix of size (n_embd, vocab_size). The # of elements in this matrix exceeded maxStorageBufferBindingSize. For example, on an 2020 M1 Mac this is around 133 million elements when GPT-2 medium's embeddings of 768 * 50304 is around 138 million elements. 

I now split this matrix (soon to be others as well) when it exceeds the maxStorageBufferBindingSize. Right now, this is done by calculating the lowest prime factor of vocab_size and chunking the calculation across the column dimension. More research needs to be done on the most efficient way of splitting matrix calculations that exceed storage limits, see comment in runGPT() in main.js.

There was also a major issue of the generate() parameters from the index.html being improperly passed, resulting in top_k param being ignored and the temperature always set to 10. This fixes a bunch of weird behavior.