### PR TITLE
Define all pipelines & bind group layouts on load.

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -21,8 +21,42 @@ async function initializeWebGPU() {
   u_s_BindLayout = createBindGroupLayout(device, ["uniform", "storage"]);
   u_s_s_s_BindLayout = createBindGroupLayout(device, ["uniform", "storage", "storage", "storage"]);
 
+  statsPipeline = createPipeline(device, normStatsShader, [u_s_BindLayout, r_BindLayout]);
+  normPipeline = createPipeline(device, normShader, [u_s_BindLayout, r_r_r_BindLayout, r_BindLayout]);
+  FFNpipeline = createPipeline(device, FFNShader, [u_r_r_s_BindLayout, r_BindLayout]);
+  GELUpipeline = createPipeline(device, GELUShader, [u_s_BindLayout, r_BindLayout]);
+  splitQKVpipeline = createPipeline(device, splitQKVShader, [u_s_s_s_BindLayout, r_BindLayout]);
+  attentionWeightsPipeline = createPipeline(device, attentionWeightsShader, [u_s_BindLayout, r_r_BindLayout]);
+  attentionValuesPipeline = createPipeline(device, attentionValuesShader, [u_s_BindLayout, r_r_BindLayout]);
+  multiplyPipeline = createPipeline(device, multiplyShader, [u_s_BindLayout, r_BindLayout]);
+  causalMaskPipeline = createPipeline(device, causalMaskShader, [u_s_BindLayout, r_BindLayout]);
+  matmulPipeline = createPipeline(device, matMulShader, [u_s_BindLayout, r_r_BindLayout]);
+  elementAddPipeline = createPipeline(device, elementWiseAdditionShader, [u_s_BindLayout, r_BindLayout, r_BindLayout]);
+  maxPipeline = createPipeline(device, negMaxShader, [u_s_BindLayout, r_BindLayout]);
+  addPipeline = createPipeline(device, addShader, [u_s_BindLayout, r_BindLayout, r_BindLayout]);
+  expPipeline = createPipeline(device, expShader, [u_s_BindLayout, r_BindLayout]);
+  sumPipeline = createPipeline(device, sumShader, [u_s_BindLayout, r_BindLayout]);
+  dividePipeline = createPipeline(device, divideShader, [u_s_BindLayout, r_BindLayout, r_BindLayout]);
+
   return { device, queue };
 }
+
+let statsPipeline;
+let normPipeline;
+let FFNpipeline;
+let GELUpipeline;
+let splitQKVpipeline;
+let attentionWeightsPipeline;
+let attentionValuesPipeline;
+let multiplyPipeline;
+let causalMaskPipeline;
+let matmulPipeline;
+let elementAddPipeline;
+let maxPipeline;
+let addPipeline;
+let expPipeline;
+let sumPipeline;
+let dividePipeline;
 
 let r_r_r_BindLayout;
 let r_r_BindLayout;

--- a/helpers.js
+++ b/helpers.js
@@ -15,7 +15,7 @@ async function initializeWebGPU() {
   bufferSizeCalc = (dimA, dimB = 1) => alignedSize(dimA * dimB * Float32Array.BYTES_PER_ELEMENT, minStorageBufferOffsetAlignment);
 
   r_r_r_BindLayout = createBindGroupLayout(device, ["read-only-storage", "read-only-storage", "read-only-storage"]);
-  r_r_BindLayout = createBindGroupLayout(device, ["read-only-storage", "read-only-storage", "read-only-storage"]);
+  r_r_BindLayout = createBindGroupLayout(device, ["read-only-storage", "read-only-storage"]);
   r_BindLayout = createBindGroupLayout(device, ["read-only-storage"]);
   u_r_r_s_BindLayout = createBindGroupLayout(device, ["uniform", "read-only-storage", "read-only-storage", "storage"]);
   u_s_BindLayout = createBindGroupLayout(device, ["uniform", "storage"]);

--- a/helpers.js
+++ b/helpers.js
@@ -14,8 +14,22 @@ async function initializeWebGPU() {
   const minStorageBufferOffsetAlignment = 1; // Should be device.limits.minStorageBufferOffsetAlignment but tis was breaking things. Fix later, not breaking just slows performance AFAIK.
   bufferSizeCalc = (dimA, dimB = 1) => alignedSize(dimA * dimB * Float32Array.BYTES_PER_ELEMENT, minStorageBufferOffsetAlignment);
 
+  r_r_r_BindLayout = createBindGroupLayout(device, ["read-only-storage", "read-only-storage", "read-only-storage"]);
+  r_r_BindLayout = createBindGroupLayout(device, ["read-only-storage", "read-only-storage", "read-only-storage"]);
+  r_BindLayout = createBindGroupLayout(device, ["read-only-storage"]);
+  u_r_r_s_BindLayout = createBindGroupLayout(device, ["uniform", "read-only-storage", "read-only-storage", "storage"]);
+  u_s_BindLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  u_s_s_s_BindLayout = createBindGroupLayout(device, ["uniform", "storage", "storage", "storage"]);
+
   return { device, queue };
 }
+
+let r_r_r_BindLayout;
+let r_r_BindLayout;
+let r_BindLayout;
+let u_r_r_s_BindLayout;
+let u_s_BindLayout;
+let u_s_s_s_BindLayout;
 
 function createShader(device, code) {
   return device.createShaderModule({

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <input type="number" min="1" max="300" value="100" id="tokensInput" disabled />
     <br /><br />
     <label for="topK">Top K:</label>
-    <input type="number" min="1" max="100" value="1" id="topKInput" disabled />
+    <input type="number" min="1" max="100" value="2" id="topKInput" disabled />
     <br /><br />
     <label for="temperature">Temperature:</label>
     <input type="number" step="0.01" min="0.1" max="2" value="1" id="temperatureInput" disabled />

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <input type="number" min="1" max="300" value="100" id="tokensInput" disabled />
     <br /><br />
     <label for="topK">Top K:</label>
-    <input type="number" min="1" max="100" value="2" id="topKInput" disabled />
+    <input type="number" min="1" max="100" value="1" id="topKInput" disabled />
     <br /><br />
     <label for="temperature">Temperature:</label>
     <input type="number" step="0.01" min="0.1" max="2" value="1" id="temperatureInput" disabled />

--- a/kernels.js
+++ b/kernels.js
@@ -628,8 +628,8 @@ const workgroup_Y = 16; // Dictated by shader.
 // --------------------- PIPELINES --------------------- //
 
 function inlineSoftmax(device, queue, commandEncoder, rows, cols, inputBuffer) {
-  const inputBufferBindGroupLayout = createBindGroupLayout(device, ["read-only-storage"]);
-  const operationBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const inputBufferBindGroupLayout = r_BindLayout;
+  const operationBindGroupLayout = u_s_BindLayout;
   const maxPipeline = createPipeline(device, negMaxShader, [operationBindGroupLayout, inputBufferBindGroupLayout]);
   const addPipeline = createPipeline(device, addShader, [operationBindGroupLayout, inputBufferBindGroupLayout, inputBufferBindGroupLayout]);
   const expPipeline = createPipeline(device, expShader, [operationBindGroupLayout, inputBufferBindGroupLayout]);
@@ -695,8 +695,8 @@ function inlineSoftmax(device, queue, commandEncoder, rows, cols, inputBuffer) {
 }
 
 function inlineResidual(device, queue, commandEncoder, rows, cols, layerOutputBuffer, residualBuffer) {
-  const inputBufferBindGroupLayout = createBindGroupLayout(device, ["read-only-storage"]);
-  const residualBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const inputBufferBindGroupLayout = r_BindLayout;
+  const residualBindGroupLayout = u_s_BindLayout;
   const residualPipeline = createPipeline(device, elementWiseAdditionShader, [residualBindGroupLayout, inputBufferBindGroupLayout, inputBufferBindGroupLayout]);
 
   const residualUniformBuffer = createBuffer(device, 16, GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST);
@@ -716,8 +716,8 @@ function inlineResidual(device, queue, commandEncoder, rows, cols, layerOutputBu
 }
 
 function inlineMatMul(device, queue, commandEncoder, Abuffer, Bbuffer, rows, cols, shared) {
-  const inputBufferBindGroupLayout = createBindGroupLayout(device, ["read-only-storage", "read-only-storage"]);
-  const matmulBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const inputBufferBindGroupLayout = r_r_BindLayout;
+  const matmulBindGroupLayout = u_s_BindLayout;
   const matmulPipeline = createPipeline(device, matMulShader, [matmulBindGroupLayout, inputBufferBindGroupLayout]);
 
   const matmulUniformBuffer = createBuffer(device, 16, GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST);
@@ -736,8 +736,8 @@ function inlineMatMul(device, queue, commandEncoder, Abuffer, Bbuffer, rows, col
 }
 
 function inlineTranspose(device, queue, commandEncoder, inputBuffer, rows, cols) {
-  const inputBufferBindGroupLayout = createBindGroupLayout(device, ["read-only-storage"]);
-  const transposeBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const inputBufferBindGroupLayout = r_BindLayout;
+  const transposeBindGroupLayout = u_s_BindLayout;
   const transposePipeline = createPipeline(device, transposeShader, [transposeBindGroupLayout, inputBufferBindGroupLayout]);
 
   const transposeUniformBuffer = createBuffer(device, 16, GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST);
@@ -756,11 +756,11 @@ function inlineTranspose(device, queue, commandEncoder, inputBuffer, rows, cols)
 }
 
 function inlineLayerNorm(device, queue, commandEncoder, seq_length, n_embd, inputBuffer, gammaBuffer, betaBuffer) {
-  const inputBufferBindGroupLayout = createBindGroupLayout(device, ["read-only-storage"]);
-  const statsBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const inputBufferBindGroupLayout = r_BindLayout;
+  const statsBindGroupLayout = u_s_BindLayout;
   const statsPipeline = createPipeline(device, normStatsShader, [statsBindGroupLayout, inputBufferBindGroupLayout]);
   const normInputBindGroupLayout = createBindGroupLayout(device, ["read-only-storage", "read-only-storage", "read-only-storage"]);
-  const normBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const normBindGroupLayout = u_s_BindLayout;
   const normPipeline = createPipeline(device, normShaderInline, [normBindGroupLayout, normInputBindGroupLayout, inputBufferBindGroupLayout]);
 
   const statsUniformBuffer = createBuffer(device, 16, GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST);
@@ -804,10 +804,10 @@ function inlineFFN(
   secondLayerWeightsBuffer,
   secondLayerBiasBuffer
 ) {
-  const inputBufferBindGroupLayout = createBindGroupLayout(device, ["read-only-storage"]);
-  const ffnBindGroupLayout = createBindGroupLayout(device, ["uniform", "read-only-storage", "read-only-storage", "storage"]);
+  const inputBufferBindGroupLayout = r_BindLayout;
+  const ffnBindGroupLayout = u_r_r_s_BindLayout;
   const FFNpipeline = createPipeline(device, FFNShader, [ffnBindGroupLayout, inputBufferBindGroupLayout]);
-  const geluBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const geluBindGroupLayout = u_s_BindLayout;
   const GELUpipeline = createPipeline(device, GELUShader, [geluBindGroupLayout, inputBufferBindGroupLayout]);
 
   const firstLayerUniformBuffer = createBuffer(device, 16, GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST);
@@ -877,18 +877,18 @@ function inlineAttention(
     throw new Error("cols must be divisible by n_head");
   }
 
-  const inputBufferBindGroupLayout = createBindGroupLayout(device, ["read-only-storage"]);
-  const ffnBindGroupLayout = createBindGroupLayout(device, ["uniform", "read-only-storage", "read-only-storage", "storage"]);
+  const inputBufferBindGroupLayout = r_BindLayout;
+  const ffnBindGroupLayout = u_r_r_s_BindLayout;
   const FFNpipeline = createPipeline(device, FFNShader, [ffnBindGroupLayout, inputBufferBindGroupLayout]);
-  const splitQKVBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage", "storage", "storage"]);
+  const splitQKVBindGroupLayout = u_s_s_s_BindLayout;
   const splitQKVpipeline = createPipeline(device, splitQKVShader, [splitQKVBindGroupLayout, inputBufferBindGroupLayout]);
-  const attentionInputBindGroupLayout = createBindGroupLayout(device, ["read-only-storage", "read-only-storage"]);
-  const attentionBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const attentionInputBindGroupLayout = r_r_BindLayout;
+  const attentionBindGroupLayout = u_s_BindLayout;
   const attentionWeightsPipeline = createPipeline(device, attentionWeightsShader, [attentionBindGroupLayout, attentionInputBindGroupLayout]);
   const attentionValuesPipeline = createPipeline(device, attentionValuesShader, [attentionBindGroupLayout, attentionInputBindGroupLayout]);
-  const multiplyBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const multiplyBindGroupLayout = u_s_BindLayout;
   const multiplyPipeline = createPipeline(device, multiplyShader, [multiplyBindGroupLayout, inputBufferBindGroupLayout]);
-  const causalMaskBindGroupLayout = createBindGroupLayout(device, ["uniform", "storage"]);
+  const causalMaskBindGroupLayout = u_s_BindLayout;
   const causalMaskPipeline = createPipeline(device, causalMaskShader, [causalMaskBindGroupLayout, inputBufferBindGroupLayout]);
 
   const qkvUniformBuffer = createBuffer(device, 16, GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST);


### PR DESCRIPTION
This is a massive improvement: I was previously re-creating pipelines and bind group layouts on every call when I could have been defining them on load and re-using them, causing very slow speeds.