### PR TITLE
Avoid checking against object built-in properties (constructor/toString/etc)

### DIFF
--- a/tokenizer.js
+++ b/tokenizer.js
@@ -162,7 +162,7 @@ function bpe(token) {
         )
       ];
 
-    if (!(bigram in tokenizer.bpe_ranks)) {
+    if (!(Object.hasOwn(tokenizer.bpe_ranks, bigram))) {
       break;
     }
 


### PR DESCRIPTION
Example: https://github.com/josephrocca/gpt-2-3-tokenizer/issues/1