### PR TITLE
Remove no-op line

### DIFF
--- a/model.js
+++ b/model.js
@@ -353,7 +353,6 @@ class GPT {
       const paddedArray = new Float32Array(params.vocab_chunk_size * params.n_embd);
       if (i === params.vocab_chunk_instances - 1) {
         size = params.vocab_size - offset;
-        paddedArray.set(size * params.n_embd, zeros((params.vocab_chunk_size * params.vocab_chunk_instances - params.vocab_size) * params.n_embd));
       }
       paddedArray.set(embeddingWeights.subarray(offset * params.n_embd, offset * params.n_embd + size * params.n_embd));
 


### PR DESCRIPTION
The removed line is imho unnecessary and can be removed for two reasons:

1) Float32Array.set takes an array and an optional numeric
   However, in the removed line, these parameters were passed
   in switched order, resulting in a no-op (afaict)

2) It seems that the idea was to zero the elements in the
   array because the last chunk is smaller than the array size.
   However, the array is already created with its values set
   to 0.