### PR TITLE
Remove toString() in lookup of this.byte_encoder

### DIFF
--- a/tokenizer.js
+++ b/tokenizer.js
@@ -96,7 +96,7 @@ class GPT2Tokenizer extends Tokenizer {
       const encoded_bytes = this.textEncoder.encode(token);
       let bytes = [];
       for (let i = 0; i < encoded_bytes.length; i++) {
-        bytes.push(this.byte_encoder[encoded_bytes[i].toString()]);
+        bytes.push(this.byte_encoder[encoded_bytes[i]]);
       }
       token = bytes.join("");
 


### PR DESCRIPTION
this.byte_encoder maps Uint8's to strings, not strings to strings.

The call to toString() is unnecessary and can be removed.